### PR TITLE
0.10.0+1.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,14 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 ## 0.10.0+1.7.1
 
-- update `cni_version` to `1.7.1`
+- **UPDATE**
+  - update `cni_version` to `1.7.1`
+
+- **MOLECULE**
+  - Use `generic/arch` Vagrant box instead of `archlinux/archlinux` (no longer available)
+  - Install `openssl` package for Archlinux
+  - Removed Ubuntu 20.04 because reached end of life
+  - Removed 'Upgrade the whole system' task
 
 ## 0.9.1+1.6.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 # Changelog
 
+## 0.10.0+1.7.1
+
+- update `cni_version` to `1.7.1`
+
 ## 0.9.1+1.6.2
 
 - update `cni_version` to `1.6.2`

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ See full [CHANGELOG](https://github.com/githubixx/ansible-role-cni/blob/master/C
 
 **Recent changes:**
 
+## 0.10.0+1.7.1
+
+- update `cni_version` to `1.7.1`
+
 ## 0.9.1+1.6.2
 
 - update `cni_version` to `1.6.2`
@@ -23,15 +27,11 @@ See full [CHANGELOG](https://github.com/githubixx/ansible-role-cni/blob/master/C
 
 - update `cni_version` to `1.6.1`
 
-## 0.8.0+1.5.1
-
-- update `cni_version` to `1.5.1`
-
 ## Role Variables
 
 ```yaml
 # CNI plugin version
-cni_version: "1.6.2"
+cni_version: "1.7.1"
 
 # CNI binary directory
 cni_bin_directory: "/opt/cni/bin"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,14 @@ See full [CHANGELOG](https://github.com/githubixx/ansible-role-cni/blob/master/C
 
 ## 0.10.0+1.7.1
 
-- update `cni_version` to `1.7.1`
+- **UPDATE**
+  - update `cni_version` to `1.7.1`
+
+- **MOLECULE**
+  - Use `generic/arch` Vagrant box instead of `archlinux/archlinux` (no longer available)
+  - Install `openssl` package for Archlinux
+  - Removed Ubuntu 20.04 because reached end of life
+  - Removed 'Upgrade the whole system' task
 
 ## 0.9.1+1.6.2
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (C) 2021-2024 Robert Wimmer
+Copyright (C) 2021-2025 Robert Wimmer
 SPDX-License-Identifier: GPL-3.0-or-later
 -->
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 # CNI plugin version
-cni_version: "1.6.2"
+cni_version: "1.7.1"
 
 # CNI binary directory
 cni_bin_directory: "/opt/cni/bin"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021-2024 Robert Wimmer
+# Copyright (C) 2021-2025 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: Restart kubelet

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021-2024 Robert Wimmer
+# Copyright (C) 2021-2025 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 galaxy_info:

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021-2024 Robert Wimmer
+# Copyright (C) 2021-2025 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: Converge

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -35,7 +35,7 @@ platforms:
         type: static
         ip: 172.16.10.30
   - name: test-cni-arch
-    box: archlinux/archlinux
+    box: generic/arch
     memory: 2048
     cpus: 2
     groups:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021-2024 Robert Wimmer
+# Copyright (C) 2021-2025 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 dependency:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -12,17 +12,6 @@ driver:
     type: libvirt
 
 platforms:
-  - name: test-cni-ubuntu2004
-    box: generic/ubuntu2004
-    memory: 2048
-    cpus: 2
-    groups:
-      - ubuntu
-    interfaces:
-      - auto_config: true
-        network_name: private_network
-        type: static
-        ip: 172.16.10.10
   - name: test-cni-ubuntu2204
     box: alvistack/ubuntu-22.04
     memory: 2048

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -20,16 +20,9 @@
         pacman -Sy
       changed_when: false
 
-    - name: Upgrade the whole system
-      ansible.builtin.raw: |
-        pacman --noconfirm -Su
-      args:
-        executable: /bin/bash
-      changed_when: false
-
     - name: Install Python
       ansible.builtin.raw: |
-        pacman -S --noconfirm python
+        pacman -S --noconfirm python openssl
       args:
         executable: /bin/bash
       changed_when: false

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021-2024 Robert Wimmer
+# Copyright (C) 2021-2025 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: Prepare Archlinux

--- a/molecule/default/tasks/check_cni_binaries.yml
+++ b/molecule/default/tasks/check_cni_binaries.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021-2024 Robert Wimmer
+# Copyright (C) 2021-2025 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: Debug output

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021-2024 Robert Wimmer
+# Copyright (C) 2021-2025 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: Verify setup

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021-2024 Robert Wimmer
+# Copyright (C) 2021-2025 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: Ensure CNI bin directory


### PR DESCRIPTION
- **UPDATE**
  - update `cni_version` to `1.7.1`

- **MOLECULE**
  - Use `generic/arch` Vagrant box instead of `archlinux/archlinux` (no longer available)
  - Install `openssl` package for Archlinux
  - Removed Ubuntu 20.04 because reached end of life
  - Removed 'Upgrade the whole system' task
